### PR TITLE
Remove rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,0 @@
-max_width = 80
-comment_width = 80


### PR DESCRIPTION
Remove existing rustfmt.toml which was not aligned with community conventions for line widths.