### PR TITLE
Cleanup tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,7 +379,7 @@ impl CliArgs {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 enum Layout {
     EvenHorizontal,
@@ -632,7 +632,7 @@ mod tests {
             String::from("select-layout"),
             String::from("-t"),
             format!("{}:{}", &session_name, &window_index),
-            String::from("even-horizontal"), // <~~ TODO: LAZY
+            config_layout.unwrap().to_string(),
         ];
         let actual = build_window_layout_args(
             &session_name,
@@ -654,7 +654,7 @@ mod tests {
             String::from("select-layout"),
             String::from("-t"),
             format!("{}:{}", &session_name, &window_index),
-            String::from("tiled"), // <~~ TODO: LAZY
+            window_layout.unwrap().to_string(),
         ];
         let actual = build_window_layout_args(
             &session_name,
@@ -675,7 +675,7 @@ mod tests {
             String::from("select-layout"),
             String::from("-t"),
             format!("{}:{}", &session_name, &window_index),
-            String::from("even-horizontal"), // <~~ TODO: LAZY
+            window_layout.unwrap().to_string(),
         ];
         let actual = build_window_layout_args(
             &session_name,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -749,8 +749,8 @@ mod tests {
     #[test]
     fn it_converts_layout_to_string() {
         let layout = Layout::Tiled;
-        let actual = String::from("tiled");
-        let expected = layout.to_string();
+        let expected = String::from("tiled");
+        let actual = layout.to_string();
         assert_eq!(expected, actual);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,7 +326,7 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum CliCommand {
     Start,
 }
@@ -341,7 +341,7 @@ impl CliCommand {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct CliArgs {
     command: CliCommand,
     project_name: String,
@@ -612,14 +612,13 @@ mod tests {
         let window_index = 2;
         let config_layout = None;
         let window_layout = None;
-        let expected = None;
         let actual = build_window_layout_args(
             &session_name,
             &window_index,
             &config_layout,
             &window_layout,
         );
-        assert_eq!(expected, actual);
+        assert!(actual.is_none());
     }
 
     #[test]
@@ -750,8 +749,8 @@ mod tests {
     #[test]
     fn it_converts_layout_to_string() {
         let layout = Layout::Tiled;
-        let expected = layout.to_string();
         let actual = String::from("tiled");
+        let expected = layout.to_string();
         assert_eq!(expected, actual);
     }
 
@@ -772,9 +771,8 @@ mod tests {
             }],
         };
 
-        let expected = None;
         let actual = build_session_start_directory(&config);
-        assert_eq!(expected, actual);
+        assert!(actual.is_none());
     }
 
     #[test]
@@ -830,12 +828,11 @@ mod tests {
                 start_directory: None,
             }],
         };
-        let expected = None;
         let actual = build_window_start_directory(
             &config.start_directory,
             &config.windows[0].start_directory,
         );
-        assert_eq!(expected, actual);
+        assert!(actual.is_none());
     }
 
     #[test]
@@ -1101,13 +1098,12 @@ mod tests {
                 start_directory: None,
             }],
         };
-        let expected = None;
         let actual = build_pane_start_directory(
             &config.start_directory,
             &config.windows[0].start_directory,
             &config.windows[0].panes[0].start_directory,
         );
-        assert_eq!(expected, actual);
+        assert!(actual.is_none());
     }
 
     #[test]
@@ -1159,7 +1155,6 @@ mod tests {
         let pane_index = 4;
         let pane_name_user_option = Some(String::from("pane_name_user_option"));
         let pane_name = None;
-        let expected = None;
         let actual = build_rename_pane_args(
             &session_name,
             window_index,
@@ -1167,7 +1162,7 @@ mod tests {
             &pane_name_user_option,
             &pane_name,
         );
-        assert_eq!(expected, actual);
+        assert!(actual.is_none());
     }
 
     #[test]
@@ -1178,7 +1173,6 @@ mod tests {
         let pane_index = 4;
         let pane_name_user_option = None;
         let pane_name = Some(String::from("pane-name"));
-        let expected = None;
         let actual = build_rename_pane_args(
             &session_name,
             window_index,
@@ -1186,50 +1180,46 @@ mod tests {
             &pane_name_user_option,
             &pane_name,
         );
-        assert_eq!(expected, actual);
+        assert!(actual.is_none());
     }
 
     #[test]
     fn it_accepts_valid_cli_command_arg() {
-        let expected = true;
-        let actual = CliCommand::new(&String::from("start")).is_ok();
-        assert_eq!(expected, actual);
+        let actual = CliCommand::new(&String::from("start"));
+        assert!(actual.is_ok());
     }
 
     #[test]
     fn it_rejects_valid_cli_command_arg() {
-        let expected = true;
-        let actual = CliCommand::new(&String::from("xtart")).is_ok();
-        assert_ne!(expected, actual);
+        let actual = CliCommand::new(&String::from("xtart"));
+        assert!(actual.is_err());
     }
 
     #[test]
     fn cli_args_requires_a_command_arg() {
         let args = vec![String::from("rmuxinator")];
-        let expected = String::from("Command is required.");
+        let expected = Err(String::from("Command is required."));
         let actual = CliArgs::new(&args);
-        assert_eq!(expected, actual.unwrap_err());
+        assert_eq!(expected, actual);
     }
 
     #[test]
     fn cli_args_requires_a_project_arg() {
         let args = vec![String::from("rmuxinator"), String::from("start")];
-        let expected = String::from("Project is required.");
+        let expected = Err(String::from("Project is required."));
         let actual = CliArgs::new(&args);
-        assert_eq!(expected, actual.unwrap_err());
+        assert_eq!(expected, actual);
     }
 
     #[test]
     fn test_for_tmux_returns_true_when_tmux_exists() {
-        let expected = true;
         let actual = test_for_tmux(String::from("tmux"));
-        assert_eq!(expected, actual);
+        assert!(actual);
     }
 
     #[test]
     fn test_for_tmux_returns_false_when_tmux_doesnt_exist() {
-        let expected = false;
         let actual = test_for_tmux(String::from("xmux"));
-        assert_eq!(expected, actual);
+        assert!(!actual);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -815,22 +815,12 @@ mod tests {
     #[test]
     fn it_uses_no_start_directory_when_none_present_for_window_start_directory()
     {
-        let config = Config {
-            pane_name_user_option: None,
-            hooks: Vec::new(),
-            layout: None,
-            name: String::from("foo"),
-            start_directory: None,
-            windows: vec![Window {
-                layout: None,
-                name: String::from("a window"),
-                panes: Vec::new(),
-                start_directory: None,
-            }],
-        };
+        let config_start_directory = None;
+        let window_start_directory = None;
+
         let actual = build_window_start_directory(
-            &config.start_directory,
-            &config.windows[0].start_directory,
+            &config_start_directory,
+            &window_start_directory,
         );
         assert!(actual.is_none());
     }
@@ -838,23 +828,13 @@ mod tests {
     #[test]
     fn it_uses_windows_start_directory_over_configs_start_directory_for_window_start_directory(
     ) {
-        let config = Config {
-            pane_name_user_option: None,
-            hooks: Vec::new(),
-            layout: None,
-            name: String::from("foo"),
-            start_directory: Some(String::from("/this/is/ignored")),
-            windows: vec![Window {
-                layout: None,
-                name: String::from("a window"),
-                panes: Vec::new(),
-                start_directory: Some(String::from("/bar/baz")),
-            }],
-        };
-        let expected = Some(String::from("/bar/baz"));
+        let config_start_directory = Some(String::from("/this/is/ignored"));
+        let window_start_directory = Some(String::from("/bar/baz"));
+
+        let expected = window_start_directory.clone();
         let actual = build_window_start_directory(
-            &config.start_directory,
-            &config.windows[0].start_directory,
+            &config_start_directory,
+            &window_start_directory,
         );
         assert_eq!(expected, actual);
     }
@@ -862,246 +842,132 @@ mod tests {
     #[test]
     fn it_uses_configs_start_directory_when_no_window_start_directory_present_for_window_start_directory(
     ) {
-        let config = Config {
-            pane_name_user_option: None,
-            hooks: Vec::new(),
-            layout: None,
-            name: String::from("foo"),
-            start_directory: Some(String::from("/foo/bar")),
-            windows: vec![Window {
-                layout: None,
-                name: String::from("a window"),
-                panes: Vec::new(),
-                start_directory: None,
-            }],
-        };
-        let expected = Some(String::from("/foo/bar"));
+        let config_start_directory = Some(String::from("/foo/bar"));
+        let window_start_directory = None;
+
+        let expected = config_start_directory.clone();
         let actual = build_window_start_directory(
-            &config.start_directory,
-            &config.windows[0].start_directory,
+            &config_start_directory,
+            &window_start_directory,
         );
         assert_eq!(expected, actual);
     }
 
     #[test]
     fn it_uses_pane_sd_when_window_sd_is_none_and_config_sd_is_none() {
-        let config = Config {
-            pane_name_user_option: None,
-            hooks: Vec::new(),
-            layout: None,
-            name: String::from("foo"),
-            start_directory: None,
-            windows: vec![Window {
-                layout: None,
-                name: String::from("a window"),
-                panes: vec![Pane {
-                    commands: vec![],
-                    name: None,
-                    start_directory: Some(String::from("/foo/bar")),
-                }],
-                start_directory: None,
-            }],
-        };
-        let expected = Some(String::from("/foo/bar"));
+        let config_start_directory = None;
+        let window_start_directory = None;
+        let pane_start_directory = Some(String::from("/foo/bar"));
+
+        let expected = pane_start_directory.clone();
         let actual = build_pane_start_directory(
-            &config.start_directory,
-            &config.windows[0].start_directory,
-            &config.windows[0].panes[0].start_directory,
+            &config_start_directory,
+            &window_start_directory,
+            &pane_start_directory,
         );
         assert_eq!(expected, actual);
     }
 
     #[test]
     fn it_uses_pane_sd_when_window_sd_is_some_and_config_sd_is_none() {
-        let config = Config {
-            pane_name_user_option: None,
-            hooks: Vec::new(),
-            layout: None,
-            name: String::from("foo"),
-            start_directory: None,
-            windows: vec![Window {
-                layout: None,
-                name: String::from("a window"),
-                panes: vec![Pane {
-                    commands: vec![],
-                    name: None,
-                    start_directory: Some(String::from("/foo/bar")),
-                }],
-                start_directory: Some(String::from("/bar/baz")),
-            }],
-        };
-        let expected = Some(String::from("/foo/bar"));
+        let config_start_directory = None;
+        let window_start_directory = Some(String::from("/bar/baz"));
+        let pane_start_directory = Some(String::from("/foo/bar"));
+
+        let expected = pane_start_directory.clone();
         let actual = build_pane_start_directory(
-            &config.start_directory,
-            &config.windows[0].start_directory,
-            &config.windows[0].panes[0].start_directory,
+            &config_start_directory,
+            &window_start_directory,
+            &pane_start_directory,
         );
         assert_eq!(expected, actual);
     }
 
     #[test]
     fn it_uses_pane_sd_when_window_sd_is_none_and_config_sd_is_some() {
-        let config = Config {
-            pane_name_user_option: None,
-            hooks: Vec::new(),
-            layout: None,
-            name: String::from("foo"),
-            start_directory: Some(String::from("/bar/baz")),
-            windows: vec![Window {
-                layout: None,
-                name: String::from("a window"),
-                panes: vec![Pane {
-                    commands: vec![],
-                    name: None,
-                    start_directory: Some(String::from("/foo/bar")),
-                }],
-                start_directory: None,
-            }],
-        };
-        let expected = Some(String::from("/foo/bar"));
+        let config_start_directory = Some(String::from("/bar/baz"));
+        let window_start_directory = None;
+        let pane_start_directory = Some(String::from("/foo/bar"));
+
+        let expected = pane_start_directory.clone();
         let actual = build_pane_start_directory(
-            &config.start_directory,
-            &config.windows[0].start_directory,
-            &config.windows[0].panes[0].start_directory,
+            &config_start_directory,
+            &window_start_directory,
+            &pane_start_directory,
         );
         assert_eq!(expected, actual);
     }
 
     #[test]
     fn it_uses_pane_sd_when_window_sd_is_some_and_config_sd_is_some() {
-        let config = Config {
-            pane_name_user_option: None,
-            hooks: Vec::new(),
-            layout: None,
-            name: String::from("foo"),
-            start_directory: Some(String::from("/bar/baz")),
-            windows: vec![Window {
-                layout: None,
-                name: String::from("a window"),
-                panes: vec![Pane {
-                    commands: vec![],
-                    name: None,
-                    start_directory: Some(String::from("/foo/bar")),
-                }],
-                start_directory: Some(String::from("/bar/baz")),
-            }],
-        };
-        let expected = Some(String::from("/foo/bar"));
+        let config_start_directory = Some(String::from("/bar/baz"));
+        let window_start_directory = Some(String::from("/bar/baz"));
+        let pane_start_directory = Some(String::from("/foo/bar"));
+
+        let expected = pane_start_directory.clone();
         let actual = build_pane_start_directory(
-            &config.start_directory,
-            &config.windows[0].start_directory,
-            &config.windows[0].panes[0].start_directory,
+            &config_start_directory,
+            &window_start_directory,
+            &pane_start_directory,
         );
         assert_eq!(expected, actual);
     }
 
     #[test]
     fn it_uses_window_sd_when_pane_sd_is_none_and_config_sd_is_none() {
-        let config = Config {
-            pane_name_user_option: None,
-            hooks: Vec::new(),
-            layout: None,
-            name: String::from("foo"),
-            start_directory: None,
-            windows: vec![Window {
-                layout: None,
-                name: String::from("a window"),
-                panes: vec![Pane {
-                    commands: vec![],
-                    name: None,
-                    start_directory: None,
-                }],
-                start_directory: Some(String::from("/foo/bar")),
-            }],
-        };
-        let expected = Some(String::from("/foo/bar"));
+        let config_start_directory = None;
+        let window_start_directory = Some(String::from("/foo/bar"));
+        let pane_start_directory = None;
+
+        let expected = window_start_directory.clone();
         let actual = build_pane_start_directory(
-            &config.start_directory,
-            &config.windows[0].start_directory,
-            &config.windows[0].panes[0].start_directory,
+            &config_start_directory,
+            &window_start_directory,
+            &pane_start_directory,
         );
         assert_eq!(expected, actual);
     }
 
     #[test]
     fn it_uses_window_sd_when_pane_sd_is_none_and_config_sd_is_some() {
-        let config = Config {
-            pane_name_user_option: None,
-            hooks: Vec::new(),
-            layout: None,
-            name: String::from("foo"),
-            start_directory: Some(String::from("/bar/baz")),
-            windows: vec![Window {
-                layout: None,
-                name: String::from("a window"),
-                panes: vec![Pane {
-                    commands: vec![],
-                    name: None,
-                    start_directory: None,
-                }],
-                start_directory: Some(String::from("/foo/bar")),
-            }],
-        };
-        let expected = Some(String::from("/foo/bar"));
+        let config_start_directory = Some(String::from("/bar/baz"));
+        let window_start_directory = Some(String::from("/foo/bar"));
+        let pane_start_directory = None;
+
+        let expected = window_start_directory.clone();
         let actual = build_pane_start_directory(
-            &config.start_directory,
-            &config.windows[0].start_directory,
-            &config.windows[0].panes[0].start_directory,
+            &config_start_directory,
+            &window_start_directory,
+            &pane_start_directory,
         );
         assert_eq!(expected, actual);
     }
 
     #[test]
     fn it_uses_config_sd_when_pane_sd_is_none_and_config_sd_is_none() {
-        let config = Config {
-            pane_name_user_option: None,
-            hooks: Vec::new(),
-            layout: None,
-            name: String::from("foo"),
-            start_directory: Some(String::from("/foo/bar")),
-            windows: vec![Window {
-                layout: None,
-                name: String::from("a window"),
-                panes: vec![Pane {
-                    commands: vec![],
-                    name: None,
-                    start_directory: None,
-                }],
-                start_directory: None,
-            }],
-        };
-        let expected = Some(String::from("/foo/bar"));
+        let config_start_directory = Some(String::from("/foo/bar"));
+        let window_start_directory = None;
+        let pane_start_directory = None;
+
+        let expected = config_start_directory.clone();
         let actual = build_pane_start_directory(
-            &config.start_directory,
-            &config.windows[0].start_directory,
-            &config.windows[0].panes[0].start_directory,
+            &config_start_directory,
+            &window_start_directory,
+            &pane_start_directory,
         );
         assert_eq!(expected, actual);
     }
 
     #[test]
     fn it_uses_no_pane_sd_when_none_are_set() {
-        let config = Config {
-            pane_name_user_option: None,
-            hooks: Vec::new(),
-            layout: None,
-            name: String::from("foo"),
-            start_directory: None,
-            windows: vec![Window {
-                layout: None,
-                name: String::from("a window"),
-                panes: vec![Pane {
-                    commands: vec![],
-                    name: None,
-                    start_directory: None,
-                }],
-                start_directory: None,
-            }],
-        };
+        let config_start_directory = None;
+        let window_start_directory = None;
+        let pane_start_directory = None;
+
         let actual = build_pane_start_directory(
-            &config.start_directory,
-            &config.windows[0].start_directory,
-            &config.windows[0].panes[0].start_directory,
+            &config_start_directory,
+            &window_start_directory,
+            &pane_start_directory,
         );
         assert!(actual.is_none());
     }


### PR DESCRIPTION
The commit messages have a pretty good step by step description, so the main changes here are to

* (adef5b0a844f519da2720dcdb5ace16bc481a324) use `assert` over `assert_*` when the value being compared in `assert_*` would be obvious as an assert (checking for `Ok`, `Err`, `None`, `true`, etc.)
* (390c855f36dcf536ce37ced3b2a2dac253a70584) Generate the layout string in the tests. This involved making `Layout` `Copy`able (just `Clone` could work, but `Copy` is appropriate because `Layout` is likely the same size as `usize`)
* (fc97b0c4ce05cf1f0d81880703ee72724980e5de) There were times when an entire dummy `Config` was created in a test that would only be using a few values. So for brevity, this was reduced to only the values that mattered