### PR TITLE
Default window and pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ pane-border-format config option)
 ## Still TODO:
 - consider building up and executing a single script (a la tmuxinator) instead
 of shelling out many times
-- make window name optional
 - support custom layouts?
 - break lib into components files (Config, CliArgs, etc.)
 - Do we need custom hooks, like tmuxinator uses for pre_window, project_start,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,7 +400,7 @@ impl fmt::Display for Layout {
 
 type StartDirectory = Option<String>;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 struct Pane {
     commands: Vec<String>,
     name: Option<String>,
@@ -411,6 +411,7 @@ struct Pane {
 struct Window {
     layout: Option<Layout>,
     name: String,
+    #[serde(default)]
     panes: Vec<Pane>,
     start_directory: StartDirectory,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ fn build_create_window_args(
 
 fn build_session_args(
     session_name: &str,
-    window_name: &Option<String>,
+    window_name: Option<String>,
     start_directory: &StartDirectory,
 ) -> Vec<String> {
     // Pass first window name to new-session, otherwise a default window gets
@@ -91,7 +91,7 @@ fn build_session_args(
 
     if let Some(_window_name) = window_name {
         session_args.push(String::from("-n"));
-        session_args.push(_window_name.to_string());
+        session_args.push(_window_name);
     }
 
     if let Some(start_directory_) = start_directory {
@@ -210,9 +210,15 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
 
     let session_start_directory = build_session_start_directory(&config);
 
+    let first_window = if let Some(window) = config.windows.get(0) {
+        window.name.clone()
+    } else {
+        None
+    };
+
     let create_session_args = build_session_args(
         session_name,
-        &config.windows[0].name,
+        first_window,
         &session_start_directory,
     );
     let error_message = String::from("Unable to create session.");
@@ -413,7 +419,7 @@ struct Pane {
     start_directory: StartDirectory,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 struct Window {
     layout: Option<Layout>,
     name: Option<String>,
@@ -511,6 +517,7 @@ pub struct Config {
     layout: Option<Layout>,
     name: String,
     start_directory: StartDirectory,
+    #[serde(default)]
     windows: Vec<Window>,
 }
 
@@ -587,7 +594,7 @@ mod tests {
             window_name.clone().unwrap(),
         ];
         let actual =
-            build_session_args(&session_name, &window_name, &start_directory);
+            build_session_args(&session_name, window_name, &start_directory);
         assert_eq!(expected, actual);
     }
 
@@ -603,7 +610,7 @@ mod tests {
             String::from(&session_name),
         ];
         let actual =
-            build_session_args(&session_name, &window_name, &start_directory);
+            build_session_args(&session_name, window_name, &start_directory);
         assert_eq!(expected, actual);
     }
 
@@ -624,7 +631,7 @@ mod tests {
             String::from(&start_directory_),
         ];
         let actual =
-            build_session_args(&session_name, &window_name, &start_directory);
+            build_session_args(&session_name, window_name, &start_directory);
         assert_eq!(expected, actual);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -573,6 +573,23 @@ mod tests {
     }
 
     #[test]
+    fn it_builds_session_args_with_window_name() {
+        let session_name = String::from("a session");
+        let window_name = Some(String::from("a window"));
+        let start_directory = None;
+        let expected = vec![
+            String::from("new-session"),
+            String::from("-d"),
+            String::from("-s"),
+            String::from(&session_name),
+            String::from("-n"),
+            window_name.clone().unwrap(),
+        ];
+        let actual = build_session_args(&session_name, window_name, &start_directory);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn it_builds_session_args_without_window_name() {
         let session_name = String::from("a session");
         let window_name = None;


### PR DESCRIPTION
**Note: this does impact what's accepted as a valid project file**

So I was working on allowing for `Default` values for `Window` and `Pane` I was wondering why `name` is required, but not in `Pane`. If `name` was also an option in `Window` then it would allow for a project file that's just

```toml
layout = "main-horizontal"
name = "example"
pane_name_user_option = "custom_pane_title"
start_directory = "/home/peter/projects/vim"
```

which is pretty bare-bones. I doubt many people would have a project file that just spawns one window with one pane, but this matches the behavior that a window with no panes still technically has one pane, so this was extended to a session with no windows still has the `Default` window. It looks like a unit test already exists for this behavior (in `it_uses_configs_start_directory_when_no_window_start_directory_present_for_session_start_directory`) so this PR would actually allow for that behavior to be used.

This is mostly just setting some foundation for trying to simplify `run` a window missing any panes will still get the default pane and the session having no windows will still get the default window, so with this change, the code can now easily reflect this same behavior.