### PR TITLE
Add debug command

### DIFF
--- a/Foo.toml
+++ b/Foo.toml
@@ -1,0 +1,2 @@
+name = "some example"
+layout = "main-horizontal"

--- a/Foo.toml
+++ b/Foo.toml
@@ -1,2 +1,0 @@
-name = "some example"
-layout = "main-horizontal"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ Optional attributes will be noted below.
 - `name` (string)
 - `start_directory` (string)
 
+### Commands
+#### `debug`
+Print the tmux commands that would be used to start and configure a tmux
+session using a path to a project config file:
+`rmuxinator debug Example.toml`
+
+#### `start`
+Start a tmux session using a path to a project config file:
+`rmuxinator start Example.toml`
+
 ## Known Issues and Workarounds
 ### Indexes
 rmuxinator currently assumes that both `base-index` and `pane-base-index` are
@@ -109,7 +119,6 @@ by adding the following:
 set -g base-index 0
 set -g pane-base-index 0
 ```
-
 
 ## Status
 This project is currently a proof of concept and I'll be duplicating tmuxinator
@@ -152,10 +161,9 @@ require writing a custom Serde deserializer for the Config type.
 - attach if session exists instead of creating sesssion
 - search for project name instead of parsing config (I'm not convinced this is
 necessary)
-- other CLI commands? (debug (for sure), stop (nice to have), create, edit,
-delete (maybe))
+- other CLI commands? (stop session, create/edit/delete project)
 - use named args in calls to format! where possible
-- document config options and provide generic sample
+- document config options
 - cut v0.0.1 release and publish binaries
 
 ## Platforms

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,6 +335,9 @@ where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
+    let project_config_file_arg = Arg::with_name("PROJECT_CONFIG_FILE")
+        .help("The path to the project config file")
+        .required(true);
     let app_matches = App::new(clap::crate_name!())
         .version(clap::crate_version!())
         .author(clap::crate_authors!())
@@ -343,20 +346,12 @@ where
         .subcommand(
             SubCommand::with_name("debug")
                 .about("Print the tmux commands that would be used to start and configure a tmux session using a path to a project config file")
-                .arg(
-                    Arg::with_name("PROJECT_CONFIG_FILE")
-                        .help("The path to the project config file")
-                        .required(true),
-                ),
+                .arg(&project_config_file_arg)
         )
         .subcommand(
             SubCommand::with_name("start")
                 .about("Start a tmux session using a path to a project config file")
-                .arg(
-                    Arg::with_name("PROJECT_CONFIG_FILE")
-                        .help("The path to the project config file")
-                        .required(true),
-                ),
+                .arg(&project_config_file_arg)
         )
         .get_matches_from(args);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,7 +309,7 @@ fn convert_config_to_tmux_commands(config: &Config) -> Vec<Vec<String>> {
 pub fn run_start(config: Config) -> Result<(), Box<dyn Error>> {
     let commands = convert_config_to_tmux_commands(&config);
 
-    for command in commands.iter() {
+    for command in commands {
         run_tmux_command(&command);
     }
 
@@ -323,12 +323,8 @@ pub fn run_start(config: Config) -> Result<(), Box<dyn Error>> {
 }
 
 pub fn run_debug(config: Config) -> Result<(), Box<dyn Error>> {
-    let commands = convert_config_to_tmux_commands(&config)
-        .iter()
-        .map(|v| v.join(" "))
-        .collect::<Vec<String>>();
-    for command in commands.iter() {
-        println!("tmux {}", command);
+    for command in convert_config_to_tmux_commands(&config) {
+        println!("tmux {}", command.join(" "));
     }
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,7 +348,7 @@ where
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(
             SubCommand::with_name("debug")
-                .about("Review the tmux commands that would be used to start and configure a tmux session using a path to a project config file")
+                .about("Print the tmux commands that would be used to start and configure a tmux session using a path to a project config file")
                 .arg(
                     Arg::with_name("PROJECT_CONFIG_FILE")
                         .help("The path to the project config file")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,10 @@ use serde::Deserialize;
 
 extern crate toml;
 
-fn run_tmux_command(command: &[String], error_message: &str) {
-    Command::new("tmux")
-        .args(command)
-        .output()
-        .expect(error_message);
+fn run_tmux_command(command: &[String]) {
+    // TODO: Validate Command status and either panic or log useful error
+    // message.
+    Command::new("tmux").args(command).output().unwrap();
 }
 
 fn build_pane_args(session_name: &str, window_index: &usize) -> Vec<String> {
@@ -313,7 +312,7 @@ pub fn run_start(config: Config) -> Result<(), Box<dyn Error>> {
     let commands = convert_config_to_tmux_commands(&config);
 
     for command in commands.iter() {
-        run_tmux_command(&command, "error");
+        run_tmux_command(&command);
     }
 
     // TODO: Move this into helper. First attempt resulted in error caused by

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,9 @@ pub fn test_for_tmux(tmux_command: &str) -> bool {
     output.status.success()
 }
 
-pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
+fn convert_config_to_tmux_commands(config: &Config) -> Vec<Vec<String>> {
+    let mut commands = vec![];
+
     let session_name = &config.name;
 
     let session_start_directory = build_session_start_directory(&config);
@@ -222,13 +224,11 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
 
     let create_session_args =
         build_session_args(session_name, first_window, &session_start_directory);
-    let error_message = "Unable to create session.";
-    run_tmux_command(&create_session_args, error_message);
+    commands.push(create_session_args);
 
-    let hook_error_message = "Unable to run set hook command";
-    for hook in config.hooks {
+    for hook in config.hooks.iter() {
         let hook_command = build_hook_args(&hook);
-        run_tmux_command(&hook_command, hook_error_message);
+        commands.push(hook_command.clone());
     }
 
     for (window_index, window) in config.windows.iter().enumerate() {
@@ -253,8 +253,7 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
                 &window_start_directory,
             );
 
-            let error_message = "Unable to run create window command.";
-            run_tmux_command(&create_window_args, error_message);
+            commands.push(create_window_args.clone());
         }
 
         for (pane_index, pane) in window.panes.iter().enumerate() {
@@ -262,8 +261,7 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
             if pane_index > 0 {
                 let pane_args = build_pane_args(session_name, &window_index);
 
-                let error_message = "Unable to run create pane command.";
-                run_tmux_command(&pane_args, error_message);
+                commands.push(pane_args.clone());
             }
 
             // Conditionally set start_directory for pane.
@@ -279,15 +277,13 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
                 let pane_command_args =
                     build_pane_command_args(session_name, &window_index, &pane_index, &command);
 
-                let error_message = "Unable to run set start_directory command for pane.";
-                run_tmux_command(&pane_command_args, error_message);
+                commands.push(pane_command_args.clone());
             }
 
             for (_, command) in pane.commands.iter().enumerate() {
                 let pane_command_args =
                     build_pane_command_args(session_name, &window_index, &pane_index, command);
-                let error_message = "Unable to run pane command.";
-                run_tmux_command(&pane_command_args, &error_message);
+                commands.push(pane_command_args.clone());
             }
 
             let rename_pane_args = build_rename_pane_args(
@@ -297,9 +293,8 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
                 &config.pane_name_user_option,
                 &pane.name.clone(),
             );
-            let error_message = "Unable to run rename pane command.";
             if let Some(rename_pane_args_) = rename_pane_args {
-                run_tmux_command(&rename_pane_args_, error_message);
+                commands.push(rename_pane_args_.clone());
             }
         }
 
@@ -307,16 +302,36 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
             build_window_layout_args(session_name, &window_index, &config.layout, &window.layout);
 
         if let Some(window_layout_args_) = window_layout_args {
-            let error_message = "Unable to set window layout.";
-            run_tmux_command(&window_layout_args_, error_message)
+            commands.push(window_layout_args_.clone());
         }
+    }
+
+    commands
+}
+
+pub fn run_start(config: Config) -> Result<(), Box<dyn Error>> {
+    let commands = convert_config_to_tmux_commands(&config);
+
+    for command in commands.iter() {
+        run_tmux_command(&command, "error");
     }
 
     // TODO: Move this into helper. First attempt resulted in error caused by
     // return type. I think I either need to return the command and then spawn
     // or return the result of calling spawn.
-    let attach_args = build_attach_args(&session_name);
+    let attach_args = build_attach_args(&config.name);
     let _attach_output = Command::new("tmux").args(&attach_args).spawn()?.wait();
+
+    Ok(())
+}
+
+pub fn run_debug(config: Config) -> Result<(), Box<dyn Error>> {
+    let commands = convert_config_to_tmux_commands(&config);
+    let flattened_commands = commands
+        .iter()
+        .map(|v| v.join(" "))
+        .collect::<Vec<String>>();
+    println!("{:#?}", flattened_commands);
 
     Ok(())
 }
@@ -331,6 +346,15 @@ where
         .author(clap::crate_authors!())
         .about(clap::crate_description!())
         .setting(AppSettings::SubcommandRequiredElseHelp)
+        .subcommand(
+            SubCommand::with_name("debug")
+                .about("Review the commands that would be used to start a tmux session using a path to a project config file")
+                .arg(
+                    Arg::with_name("PROJECT_CONFIG_FILE")
+                        .help("The path to the project config file")
+                        .required(true),
+                ),
+        )
         .subcommand(
             SubCommand::with_name("start")
                 .about("Start a tmux session using a path to a project config file")
@@ -369,6 +393,7 @@ where
 
 #[derive(Debug, PartialEq)]
 pub enum CliCommand {
+    Debug,
     Start,
 }
 
@@ -391,6 +416,7 @@ impl FromStr for CliCommand {
     type Err = ParseCliCommandError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            "debug" => Ok(Self::Debug),
             "start" => Ok(Self::Start),
             // This should only ever be reached if subcommands are added to
             // clap and not here
@@ -1061,6 +1087,26 @@ mod tests {
             &pane_name,
         );
         assert!(actual.is_none());
+    }
+
+    #[test]
+    fn it_computes_the_expected_commands() {
+        let config = Config {
+            hooks: vec![],
+            layout: None,
+            name: String::from("most basic config"),
+            pane_name_user_option: None,
+            start_directory: None,
+            windows: vec![],
+        };
+        let expected = vec![vec![
+            String::from("new-session"),
+            String::from("-d"),
+            String::from("-s"),
+            String::from("most basic config"),
+        ]];
+        let actual = convert_config_to_tmux_commands(&config);
+        assert_eq!(expected, actual);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,12 +326,13 @@ pub fn run_start(config: Config) -> Result<(), Box<dyn Error>> {
 }
 
 pub fn run_debug(config: Config) -> Result<(), Box<dyn Error>> {
-    let commands = convert_config_to_tmux_commands(&config);
-    let flattened_commands = commands
+    let commands = convert_config_to_tmux_commands(&config)
         .iter()
         .map(|v| v.join(" "))
         .collect::<Vec<String>>();
-    println!("{:#?}", flattened_commands);
+    for command in commands.iter() {
+        println!("tmux {}", command);
+    }
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ fn convert_config_to_tmux_commands(config: &Config) -> Vec<Vec<String>> {
 
     for hook in config.hooks.iter() {
         let hook_command = build_hook_args(&hook);
-        commands.push(hook_command.clone());
+        commands.push(hook_command);
     }
 
     for (window_index, window) in config.windows.iter().enumerate() {
@@ -252,15 +252,14 @@ fn convert_config_to_tmux_commands(config: &Config) -> Vec<Vec<String>> {
                 &window_start_directory,
             );
 
-            commands.push(create_window_args.clone());
+            commands.push(create_window_args);
         }
 
         for (pane_index, pane) in window.panes.iter().enumerate() {
             // Pane 0 is created by default by the containing window
             if pane_index > 0 {
                 let pane_args = build_pane_args(session_name, &window_index);
-
-                commands.push(pane_args.clone());
+                commands.push(pane_args);
             }
 
             // Conditionally set start_directory for pane.
@@ -275,14 +274,13 @@ fn convert_config_to_tmux_commands(config: &Config) -> Vec<Vec<String>> {
                 let command = format!("cd {}", pane_start_directory);
                 let pane_command_args =
                     build_pane_command_args(session_name, &window_index, &pane_index, &command);
-
-                commands.push(pane_command_args.clone());
+                commands.push(pane_command_args);
             }
 
             for (_, command) in pane.commands.iter().enumerate() {
                 let pane_command_args =
                     build_pane_command_args(session_name, &window_index, &pane_index, command);
-                commands.push(pane_command_args.clone());
+                commands.push(pane_command_args);
             }
 
             let rename_pane_args = build_rename_pane_args(
@@ -293,7 +291,7 @@ fn convert_config_to_tmux_commands(config: &Config) -> Vec<Vec<String>> {
                 &pane.name.clone(),
             );
             if let Some(rename_pane_args_) = rename_pane_args {
-                commands.push(rename_pane_args_.clone());
+                commands.push(rename_pane_args_);
             }
         }
 
@@ -301,7 +299,7 @@ fn convert_config_to_tmux_commands(config: &Config) -> Vec<Vec<String>> {
             build_window_layout_args(session_name, &window_index, &config.layout, &window.layout);
 
         if let Some(window_layout_args_) = window_layout_args {
-            commands.push(window_layout_args_.clone());
+            commands.push(window_layout_args_);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,7 +349,7 @@ where
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(
             SubCommand::with_name("debug")
-                .about("Review the commands that would be used to start a tmux session using a path to a project config file")
+                .about("Review the tmux commands that would be used to start and configure a tmux session using a path to a project config file")
                 .arg(
                     Arg::with_name("PROJECT_CONFIG_FILE")
                         .help("The path to the project config file")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 extern crate rmuxinator;
 
-use rmuxinator::{parse_args, run, test_for_tmux, CliCommand, Config};
+use rmuxinator::{parse_args, run_debug, run_start, test_for_tmux, CliCommand, Config};
 use std::env;
 
 fn main() -> Result<(), String> {
@@ -19,7 +19,10 @@ fn main() -> Result<(), String> {
 
     match cli_args.command {
         CliCommand::Start => {
-            run(config).map_err(|error| format!("Application error: {}", error))
+            run_start(config).map_err(|error| format!("Application error: {}", error))
+        }
+        CliCommand::Debug => {
+            run_debug(config).map_err(|error| format!("Application error: {}", error))
         }
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -23,7 +23,7 @@ fn it_returns_the_expected_debug_output() -> Result<(), Box<dyn std::error::Erro
         "
     )?;
 
-    // TODO: The indentation used below is very touchy. There must be a better
+    // TODO: The indentation used below is very fragile. There must be a better
     // nicer, more robust solution to formatting multiline strings.
     Command::cargo_bin(env!("CARGO_PKG_NAME"))?
         .arg("debug")

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -11,6 +11,21 @@ use tempfile::NamedTempFile;
 // for its presence.
 
 #[test]
+fn it_returns_the_expected_debug_output() -> Result<(), Box<dyn std::error::Error>> {
+    let mut file = NamedTempFile::new()?;
+    writeln!(file, "name = \"debug project\"")?;
+
+    Command::cargo_bin(env!("CARGO_PKG_NAME"))?
+        .arg("debug")
+        .arg(file.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("new-session -d -s debug project"));
+
+    Ok(())
+}
+
+#[test]
 fn no_args() -> Result<(), Box<dyn std::error::Error>> {
     let long_help = format!(
         r#"{} {}
@@ -25,6 +40,7 @@ FLAGS:
     -V, --version    Prints version information
 
 SUBCOMMANDS:
+    debug    Review the commands that would be used to start a tmux session using a path to a project config file
     help     Prints this message or the help of the given subcommand(s)
     start    Start a tmux session using a path to a project config file"#,
         env!("CARGO_PKG_NAME"),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -53,7 +53,7 @@ FLAGS:
     -V, --version    Prints version information
 
 SUBCOMMANDS:
-    debug    Review the tmux commands that would be used to start and configure a tmux session using a path to a
+    debug    Print the tmux commands that would be used to start and configure a tmux session using a path to a
              project config file
     help     Prints this message or the help of the given subcommand(s)
     start    Start a tmux session using a path to a project config file"#,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -53,7 +53,8 @@ FLAGS:
     -V, --version    Prints version information
 
 SUBCOMMANDS:
-    debug    Review the commands that would be used to start a tmux session using a path to a project config file
+    debug    Review the tmux commands that would be used to start and configure a tmux session using a path to a
+             project config file
     help     Prints this message or the help of the given subcommand(s)
     start    Start a tmux session using a path to a project config file"#,
         env!("CARGO_PKG_NAME"),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -13,14 +13,27 @@ use tempfile::NamedTempFile;
 #[test]
 fn it_returns_the_expected_debug_output() -> Result<(), Box<dyn std::error::Error>> {
     let mut file = NamedTempFile::new()?;
-    writeln!(file, "name = \"debug project\"")?;
+    writeln!(
+        file,
+        "name = \"debug\"
+        [[windows]]
+          name = \"one\"
+        [[windows]]
+          name = \"two\"
+        "
+    )?;
 
+    // TODO: The indentation used below is very touchy. There must be a better
+    // nicer, more robust solution to formatting multiline strings.
     Command::cargo_bin(env!("CARGO_PKG_NAME"))?
         .arg("debug")
         .arg(file.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains("new-session -d -s debug project"));
+        .stdout(predicate::str::contains(
+            "tmux new-session -d -s debug -n one
+tmux new-window -t debug:1 -n two",
+        ));
 
     Ok(())
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -13,15 +13,14 @@ use tempfile::NamedTempFile;
 #[test]
 fn it_returns_the_expected_debug_output() -> Result<(), Box<dyn std::error::Error>> {
     let mut file = NamedTempFile::new()?;
-    writeln!(
-        file,
-        "name = \"debug\"
+    let file_contents = r#"
+        name = "debug"
         [[windows]]
-          name = \"one\"
+          name = "one"
         [[windows]]
-          name = \"two\"
-        "
-    )?;
+          name = "two"
+        "#;
+    writeln!(file, "{}", file_contents)?;
 
     // TODO: The indentation used below is very fragile. There must be a better
     // nicer, more robust solution to formatting multiline strings.


### PR DESCRIPTION
This command prints the list of tmux commands that rmuxinator will use to create and configure a tmux session. This can be used by users trying to better understand what rmuxinator is doing on their behalf and when submitting bug reports.

Another approach that @LovecraftianHorror and I had discussed was adding a `--dry-run` flag to the `start` command. The approach used here emulates tmuxinator (which may help with adoption) and the implementation was (IMO) simpler. I'm still open to adding that flag to `start`, though.

Closes #20.