### PR TITLE
Feature - Introduce "attached" config option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "rmuxinator"
-version = "2.0.0"
+version = "1.1.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "downcast"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +136,21 @@ checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fragile"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7464c5c4a3f014d9b2ec4073650e5c06596f385060af740fc45ad5a19f959e8"
+dependencies = [
+ "fragile 2.0.0",
+]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "hermit-abi"
@@ -175,6 +196,33 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "mockall"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab571328afa78ae322493cacca3efac6a0f2e0a67305b4df31fd439ef129ac0"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile 1.2.2",
+ "lazy_static",
+ "mockall_derive",
+ "predicates 1.0.8",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e25b214433f669161f414959594216d8e6ba83b6679d3db96899c0b4639033"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -233,18 +281,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -292,10 +340,11 @@ dependencies = [
 
 [[package]]
 name = "rmuxinator"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "assert_cmd",
  "clap",
+ "mockall",
  "predicates 1.0.8",
  "serde",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ keywords = ["tmux", "productivity"]
 
 [dependencies]
 clap = "2.33"
-toml = "0.4"
-serde = { version = "1.0", features = ["derive"] }
 mockall = "0.10"
+serde = { version = "1.0", features = ["derive"] }
+toml = "0.4"
 
 [dev-dependencies]
 assert_cmd = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmuxinator"
-version = "2.0.0"
+version = "1.1.0"
 authors = ["Peter Doherty <pdoherty@protonmail.com>"]
 edition = "2018"
 description = "tmux project configuration utility"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmuxinator"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Peter Doherty <pdoherty@protonmail.com>"]
 edition = "2018"
 description = "tmux project configuration utility"
@@ -12,6 +12,7 @@ keywords = ["tmux", "productivity"]
 clap = "2.33"
 toml = "0.4"
 serde = { version = "1.0", features = ["derive"] }
+mockall = "0.10"
 
 [dev-dependencies]
 assert_cmd = "1"

--- a/Example.toml
+++ b/Example.toml
@@ -1,3 +1,4 @@
+attached = false
 layout = "main-horizontal"
 name = "example"
 pane_name_user_option = "custom_pane_title"

--- a/Example.toml
+++ b/Example.toml
@@ -1,4 +1,4 @@
-attached = false
+attached = true
 layout = "main-horizontal"
 name = "example"
 pane_name_user_option = "custom_pane_title"

--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ require writing a custom Serde deserializer for the Config type.
 config (I'm not convinced this is necessary)
 - Other CLI commands? (stop session, create/edit/delete project)
 - Use named args in calls to format! where possible
+- Scope mockall dependencies to test env
+- Implement default for Config struct
 
 ## Platforms
 Here are the platforms rmuxinator is known to work on:

--- a/README.md
+++ b/README.md
@@ -224,7 +224,6 @@ require writing a custom Serde deserializer for the Config type.
 config (I'm not convinced this is necessary)
 - Other CLI commands? (stop session, create/edit/delete project)
 - Use named args in calls to format! where possible
-- Scope mockall dependencies to test env
 - Implement default for Config struct
 
 ## Platforms

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Optional attributes will be noted below.
 - `windows` (array; see dedicated entry)
 
 ###### Optional
+-  attached (bool; whether or not to attach to newly created tmux session)
 - `hooks` (array; see dedicated entry)
 - `layout` (string; preset tmux layouts: "even-horizontal", "even-vertical", "main-horizontal", "main-vertical", "tiled")
 - `pane_name_user_option` (string; must have matching entry in .tmux.conf (e.g.  `set -g pane-border-format "#{@custom_pane_title}"`)
@@ -216,7 +217,6 @@ remove themselves in order to prevent duplicate events.
 - Handle shell failures -- `tmux kill-window` was failing silently
 - Can commands can all be moved into structs and computed up front? This might
 require writing a custom Serde deserializer for the Config type.
-- Start detached tmux session
 - Select window on attach (can this be handled by a pre-existing hook?)
 - Attach if session exists instead of creating sesssion
 - Search for project config file on disk (XDG_CONFIG?) instead of parsing

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Optional attributes will be noted below.
 - `windows` (array; see dedicated entry)
 
 ###### Optional
--  attached (bool; whether or not to attach to newly created tmux session)
+-  attached (bool; defaults to `true`; whether or not to attach to newly created tmux session)
 - `hooks` (array; see dedicated entry)
 - `layout` (string; preset tmux layouts: "even-horizontal", "even-vertical", "main-horizontal", "main-vertical", "tiled")
 - `pane_name_user_option` (string; must have matching entry in .tmux.conf (e.g.  `set -g pane-border-format "#{@custom_pane_title}"`)

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Example:
 
 ```
 let rmuxinator_config = rmuxinator::Config {
+    attached: true,
     hooks: vec![],
     layout: None,
     name: String::from("rmuxinator-library-example"),

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Example:
 
 ```
 let config = rmuxinator::Config::new_from_config_path(&String::from("/home/pi/foo.toml")).map_err(|error| format!("Problem parsing config file: {}", error))?;
-rmuxinator::run_start(config).map_err(|error| format!("Application error: {}", error));
+rmuxinator::run_start(config, None).map_err(|error| format!("Application error: {}", error));
 ```
 
 #### Config constructor
@@ -168,7 +168,7 @@ let rmuxinator_config = rmuxinator::Config {
     ];
 
 };
-rmuxinator::run_start(rmuxinator_config).map_err(|error| format!("Rmuxinator error: {}", error))
+rmuxinator::run_start(rmuxinator_config, None).map_err(|error| format!("Rmuxinator error: {}", error))
 ```
 
 ## Known Issues and Workarounds

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Example:
 
 ```
 let config = rmuxinator::Config::new_from_config_path(&String::from("/home/pi/foo.toml")).map_err(|error| format!("Problem parsing config file: {}", error))?;
-rmuxinator::run_start(config, None).map_err(|error| format!("Application error: {}", error));
+rmuxinator::run_start(config).map_err(|error| format!("Rmuxinator error: {}", error));
 ```
 
 #### Config constructor
@@ -168,7 +168,7 @@ let rmuxinator_config = rmuxinator::Config {
     ];
 
 };
-rmuxinator::run_start(rmuxinator_config, None).map_err(|error| format!("Rmuxinator error: {}", error))
+rmuxinator::run_start(rmuxinator_config).map_err(|error| format!("Rmuxinator error: {}", error))
 ```
 
 ## Known Issues and Workarounds

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use clap::{App, AppSettings, Arg, SubCommand};
+use serde::{Deserialize, Serialize};
 use std::error::Error;
 use std::ffi::OsString;
 use std::fmt;
@@ -5,9 +7,6 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::process::Command;
 use std::str::FromStr;
-
-use clap::{App, AppSettings, Arg, SubCommand};
-use serde::{Deserialize, Serialize};
 
 extern crate toml;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,15 @@ use std::str::FromStr;
 
 extern crate toml;
 
-// All of the following automock and *Factory business exists to facilitate
-// mocking. Coming from a dynamic language background, this does not smell
-// right to me but I don't see any way around it. Attempts to scope the mocking
-// to the test env via `#[cfg(test)]` were unsuccessful and seem to rely on
-// "nightly" features which also doesn't smell like a good idea. So, that's all
-// to excuse this boilerplate and cluttering of the main module. I may wind up
-// yanking this out in favor of a different mocking library, integration tests
-// or reliance on isolated unit tests which exercise this same behavior.
+// The following automock and *Factory business exists to facilitate mocking.
+// Coming from a dynamic language background, this does not smell right to me
+// but I don't see any way around it. Attempts to scope the mocking to the test
+// env via `#[cfg(test)]` were unsuccessful and seem to rely on "nightly"
+// features which also doesn't smell like a good idea. So, that's all to excuse
+// this boilerplate and cluttering of the main module.
+// I may wind up yanking this out in favor of a different mocking library,
+// integration tests or reliance on isolated unit tests which exercise this
+// same behavior.
 // UPDATE: I'm now mocking run_tmux_command instead of Command, which feels
 // only slightly better because at least it's something we _own_ (in TDD
 // parlance). The CommandFactories can probably go away unless we really want
@@ -27,16 +28,17 @@ extern crate toml;
 // correct arguments to Command. In an ideal world, we would but it will
 // require additional layers of indirection/mocking to verify that the correct
 // args method is being called on the mocked Command ...
+// - ethagnawl
 
 #[automock]
 pub trait CommandFactory {
-    fn new_(&self, program: &String) -> Command;
+    fn new_(&self, program: &str) -> Command;
 }
 
 pub struct RealCommandFactory;
 
 impl CommandFactory for RealCommandFactory {
-    fn new_(&self, program: &String) -> Command {
+    fn new_(&self, program: &str) -> Command {
         Command::new(program)
     }
 }
@@ -48,7 +50,7 @@ fn run_tmux_command(
 ) -> Result<(), Box<dyn Error>> {
     // TODO: Validate Command status and either panic or log useful error
     // message.
-    let mut tmux = command_factory.new_(&String::from("tmux"));
+    let mut tmux = command_factory.new_("tmux");
     if wait {
         let _ = tmux.args(command).spawn()?.wait();
     } else {
@@ -374,26 +376,26 @@ fn convert_config_to_tmux_commands(config: &Config) -> Vec<(Vec<String>, bool)> 
     commands
 }
 
-pub fn run_start(
+fn run_start_(
     config: Config,
-    tmux_command_runner: Option<&dyn TmuxCommandRunner>,
+    tmux_command_runner: &dyn TmuxCommandRunner,
 ) -> Result<(), Box<dyn Error>> {
-    // TODO: Is this really better than having the caller supply a
-    // TmuxCommandRunner? At least that's obvious ...
-    let tmux_command_runner_ = match tmux_command_runner {
-        Some(tmux_command_runner) => tmux_command_runner,
-        None => &RealTmuxCommandRunner,
-    };
-
     let commands = convert_config_to_tmux_commands(&config);
-
     let factory = RealCommandFactory;
-
     for command in commands {
-        let _ = tmux_command_runner_.run_tmux_command(&factory, &command.0, command.1);
+        let _ = tmux_command_runner.run_tmux_command(&factory, &command.0, command.1);
     }
-
     Ok(())
+}
+
+pub fn run_start(config: Config) -> Result<(), Box<dyn Error>> {
+    // NOTE: This exists to prevent the public API from having to change in
+    // order pass in an optional TmuxCommandRunner (e.g. None). As noted above
+    // this indirection exists soley to facilitate mocking run_tmux_command in
+    // the test env. This is the best approach I've hit upon yet but I'm
+    // still not convinced it's a good, worthwhile idea.
+    // - ethagnawl
+    run_start_(config, &RealTmuxCommandRunner)
 }
 
 pub fn run_debug(config: Config) -> Result<(), Box<dyn Error>> {
@@ -700,7 +702,7 @@ mod tests {
             })
             .with(always(), always(), eq(false))
             .returning(|_x, _y, _z| (Ok(())));
-        let _ = run_start(config, Some(&mock));
+        let _ = run_start_(config, &mock);
     }
 
     #[test]
@@ -736,7 +738,7 @@ mod tests {
             .with(always(), always(), eq(true))
             .returning(|_x, _y, _z| (Ok(())));
 
-        let _ = run_start(config, Some(&mock));
+        let _ = run_start_(config, &mock);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -817,6 +817,7 @@ mod tests {
     #[test]
     fn it_uses_no_start_directory_when_none_present_for_session_start_directory() {
         let config = Config {
+            attached: true,
             pane_name_user_option: None,
             hooks: Vec::new(),
             layout: None,
@@ -838,6 +839,7 @@ mod tests {
     fn it_uses_configs_start_directory_when_no_window_start_directory_present_for_session_start_directory(
     ) {
         let config = Config {
+            attached: true,
             pane_name_user_option: None,
             hooks: Vec::new(),
             layout: None,
@@ -853,6 +855,7 @@ mod tests {
     #[test]
     fn it_uses_windows_start_directory_over_configs_start_directory_for_session_start_directory() {
         let config = Config {
+            attached: true,
             pane_name_user_option: None,
             hooks: Vec::new(),
             layout: None,
@@ -1097,6 +1100,7 @@ mod tests {
     #[test]
     fn it_computes_the_expected_commands() {
         let config = Config {
+            attached: false,
             hooks: vec![],
             layout: None,
             name: String::from("most basic config"),
@@ -1104,12 +1108,15 @@ mod tests {
             start_directory: None,
             windows: vec![],
         };
-        let expected = vec![vec![
-            String::from("new-session"),
-            String::from("-d"),
-            String::from("-s"),
-            String::from("most basic config"),
-        ]];
+        let expected = vec![(
+            vec![
+                String::from("new-session"),
+                String::from("-d"),
+                String::from("-s"),
+                String::from("most basic config"),
+            ],
+            false,
+        )];
         let actual = convert_config_to_tmux_commands(&config);
         assert_eq!(expected, actual);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), String> {
 
     match cli_args.command {
         CliCommand::Start => {
-            run_start(config, None).map_err(|error| format!("Application error: {}", error))
+            run_start(config).map_err(|error| format!("Application error: {}", error))
         }
         CliCommand::Debug => {
             run_debug(config).map_err(|error| format!("Application error: {}", error))

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), String> {
 
     match cli_args.command {
         CliCommand::Start => {
-            run_start(config).map_err(|error| format!("Application error: {}", error))
+            run_start(config, None).map_err(|error| format!("Application error: {}", error))
         }
         CliCommand::Debug => {
             run_debug(config).map_err(|error| format!("Application error: {}", error))


### PR DESCRIPTION
This feature will allow users to start a tmux session without attaching to it. In order to prevent breaking API changes, the default value is `true`, which mimics the behavior of previous versions of this application.

This behavior is made available via the following k/v in a project's config file:

```
attached: true|false
```

This PR also introduces mockall as a new dependency to facilitate mocking in unit tests. I'm not thrilled with the way this is currently being done, as it introduces at least one layer of indirection to the application to facilitate the mocking via dependency injection of the "tmux command runner" to the `run_start` function ~~and pollutes the rmuxinator module with test-specific code~~. I'm going to think about this approach for a bit and see about other patterns or libraries which might make this all a bit tidier. Though, the current implementation does work, so maybe this is best dealt with in a future release. I'd love to hear feedback from others about any/all of this, as this is my first foray into doing any sort of mocking in Rust.

This change set also introduces a refactoring which adds a `wait` argument to the `run_tmux_command` function and uses it as the sole method of shelling out to tmux instead of having the final "attach" (i.e. spawn/wait) command issued inline.