### PR TITLE
#45 - Prevent "no space for new pane" pane split errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,11 +55,26 @@ impl TmuxCommandRunner for TmuxWrapper {
     }
 }
 
-fn build_pane_args(session_name: &str, window_index: &usize) -> Vec<String> {
+fn build_pane_args(session_name: &str, window_index: usize) -> Vec<String> {
+    // NOTE: Like tmuxinator does, we want to continually apply the tiled layout
+    // after splitting and then _only_ at the very end of the window config
+    // constructor context apply the specified or inherited layout. This
+    // prevents errors like, "no space for new pane" which occur if the
+    // window's current size/layout won't (otherwise) allow it to be split
+    // again.
+    // It probably makes sense to declare tiled as the default layout so this
+    // behavior doesn't surprise anyone.
+    // See:
+    // - https://github.com/ethagnawl/rmuxinator/issues/45
+    // - https://www.mail-archive.com/tmux-users@googlegroups.com/msg01241.html
     vec![
         String::from("split-window"),
         String::from("-t"),
+        format!("{}:{};", session_name, window_index.to_string()),
+        String::from("select-layout"),
+        String::from("-t"),
         format!("{}:{}", session_name, window_index.to_string()),
+        String::from("tiled"),
     ]
 }
 
@@ -333,7 +348,7 @@ fn convert_config_to_tmux_commands(
             let pane_index = base_indices.pane_base_index + pane_iterator_index;
             // The "first" pane is created by default by the containing window
             if pane_iterator_index > 0 {
-                let pane_args = build_pane_args(session_name, &window_index);
+                let pane_args = build_pane_args(session_name, window_index);
                 commands.push((pane_args, false));
             }
 


### PR DESCRIPTION
Always set layout to tile after splitting pane to prevent "no space for new pane" errors.

- [ ] document and/or default to tiled layout to prevent unexpected behavior when panes are split without an explicitly specified layout